### PR TITLE
Remove all recommendations which open tabs with sketchy malware ads

### DIFF
--- a/data/recommendation/localData.json
+++ b/data/recommendation/localData.json
@@ -60,58 +60,8 @@
     ]
   },
   {
-    "domain": "youtube.com",
-    "data": [
-      {
-        "description": "Play all YouTube videos in high-def.",
-        "id": "{7b1bf0b6-a1b9-42b0-b75d-252036438bdc}",
-        "imageURL": "https://addons.cdn.mozilla.net/user-media/addon_icons/328/328839-64.png",
-        "infoURL": "https://addons.mozilla.org/en-US/firefox/addon/youtube-high-definition/",
-        "name": "YouTube High Definition",
-        "packageURL": "https://addons.mozilla.org/firefox/downloads/latest/youtube-high-definition/addon-328839-latest.xpi"
-      }
-    ]
-  },
-  {
-    "domain": "weather.com",
-    "data": [
-      {
-        "description": "Get instant weather reports right from the browser.",
-        "id": "jid1-w3xH9kJhd3KJUp@jetpack",
-        "imageURL": "https://addons.cdn.mozilla.net/user-media/addon_icons/549/549766-64.png",
-        "infoURL": "https://addons.mozilla.org/en-US/firefox/addon/weather-forecast-plus/",
-        "name": "Weather Underground",
-        "packageURL": "https://addons.mozilla.org/firefox/downloads/latest/weather-forecast-plus/addon-549766-latest.xpi"
-      }
-    ]
-  },
-  {
     "domain": "facebook.com",
     "data": [
-      {
-        "description": "Bring Messenger right into your browser for easy access anytime.",
-        "id": "{249b4e45-4fb9-4f6b-9754-7c0c1e605d44}",
-        "imageURL": "https://addons.cdn.mozilla.net/user-media/addon_icons/412/412584-64.png",
-        "infoURL": "https://addons.mozilla.org/en-US/firefox/addon/facebook-messenger/",
-        "name": "Facebook Messenger",
-        "packageURL": "https://addons.mozilla.org/firefox/downloads/latest/facebook-messenger/addon-412584-latest.xpi"
-      },
-      {
-        "description": "Prevent Facebook from tracking websites you visit.",
-        "id": "jid0-dBgF7UkIiOsWqvBng4hYu@jetpack",
-        "imageURL": "https://addons.cdn.mozilla.net/user-media/addon_icons/593/593930-64.png",
-        "infoURL": "https://addons.mozilla.org/en-US/firefox/addon/facebook-disconnect/",
-        "name": "Facebook Disconnect",
-        "packageURL": "https://addons.mozilla.org/firefox/downloads/latest/facebook-disconnect/addon-593930-latest.xpi"
-      },
-      {
-        "description": "Magnify Facebook pics for up-close views.",
-        "id": "{7c6cdf7c-8ea8-4be7-ae5a-0b3effe14d66}",
-        "imageURL": "https://addons.cdn.mozilla.net/user-media/addon_icons/429/429680-64.png",
-        "infoURL": "https://addons.mozilla.org/en-US/firefox/addon/facebook-photo-zoom/",
-        "name": "Facebook Photo Zoom",
-        "packageURL": "https://addons.mozilla.org/firefox/downloads/latest/facebook-photo-zoom/addon-429680-latest.xpi"
-      },
       {
         "description": "Enjoy enhanced access to Facebook emoticons.",
         "id": "jid0-XZn6pYCdV3ANrfYigxlyyGDrxAM@jetpack",
@@ -119,45 +69,6 @@
         "infoURL": "https://addons.mozilla.org/en-US/firefox/addon/facebook-secret-emoticons/",
         "name": "Emoticons for Facebook",
         "packageURL": "https://addons.mozilla.org/firefox/downloads/latest/facebook-secret-emoticons/addon-454042-latest.xpi"
-      }
-    ]
-  },
-  {
-    "domain": "twitter.com",
-    "data": [
-      {
-        "description": "Access Twitter from your browser sidebar.",
-        "id": "{12b6fdcd-4423-4276-82a3-73fdbff5f7e4}",
-        "imageURL": "https://addons.cdn.mozilla.net/user-media/addon_icons/423/423970-64.png",
-        "infoURL": "https://addons.mozilla.org/en-US/firefox/addon/twitter-app/",
-        "name": "Twitter App",
-        "packageURL": "https://addons.mozilla.org/firefox/downloads/latest/twitter-app/addon-423970-latest.xpi"
-      }
-    ]
-  },
-  {
-    "domain": "pinterest.com",
-    "data": [
-      {
-        "description": "Send images to your Pinterest page with just one click. ",
-        "id": "{677a8f98-fd64-40b0-a883-b8c95d0cbf17}",
-        "imageURL": "https://addons.cdn.mozilla.net/user-media/addon_icons/428/428922-64.png",
-        "infoURL": "https://addons.mozilla.org/en-US/firefox/addon/pinterest-pin-button/",
-        "name": "Share Button",
-        "packageURL": "https://addons.mozilla.org/firefox/downloads/latest/pinterest-pin-button/addon-428922-latest.xpi"
-      }
-    ]
-  },
-  {
-    "domain": "gmail.com",
-    "data": [
-      {
-        "description": "Get Gmail alerts, read, reply, delete, and more — right from the browser toolbar.",
-        "id": "jid1-sqmEAwSoa3FZPc@jetpack",
-        "imageURL": "https://addons.cdn.mozilla.net/user-media/addon_icons/521/521580-64.png",
-        "infoURL": "https://addons.mozilla.org/en-US/firefox/addon/fastest-notifier-for-gmail/",
-        "name": "Gmail Notifier",
-        "packageURL": "https://addons.mozilla.org/firefox/downloads/latest/fastest-notifier-for-gmail/addon-521580-latest.xpi"
       }
     ]
   },


### PR DESCRIPTION
This constraint removes a lot of the recommendations. There are only 7 left if we remove all of these, so we should probably find some new ones. None of the 7 remaining add-ons open new tabs on install. 

r? 
