### PR TITLE
Fix panel close listener that didn't remove itself properly

### DIFF
--- a/lib/Recommend.js
+++ b/lib/Recommend.js
@@ -26,6 +26,7 @@ class Recommender {
     this.createRequestListener('disableSite');
     this.createRequestListener('disableForever');
     this.createWindowListeners();
+    this.endOnboard = this.endOnboard.bind(this);
   }
 
   start() {
@@ -53,13 +54,13 @@ class Recommender {
         const button = this.getButton(win);
         this.showPanel(button);
         TelemetryLog.onboard();
-        this.panel.on('hide', this.endOnboard.bind(this));
+        this.panel.on('hide', this.endOnboard);
       },
     });
   }
 
   endOnboard() {
-    this.panel.removeListener('hide', this.endOnboard.bind(this));
+    this.panel.removeListener('hide', this.endOnboard);
     this.panel.port.emit('endOnboard');
     TelemetryLog.endOnboard();
     simplePrefs.prefs.onboarded = true;


### PR DESCRIPTION
The panel close listener that evoked the "endOnboard" function previously didn't remove itself properly, so the "endOnboard" function would be called on every panel close (instead of just the first one).

@mythmon r? 
