### PR TITLE
Apply "box-sizing: border-box" to all elements

### DIFF
--- a/data/recommendation/_installButton.scss
+++ b/data/recommendation/_installButton.scss
@@ -45,7 +45,7 @@ $switchToBackgroundRatio: 2.7;
 $switchStrokeOff: #858585;
 $switchStrokeOn: #00a920;
 $switchStrokeWidth: 1px;
-$switchHandleActivePosition: round(($size * $switchToBackgroundRatio) - ($size + $switchStrokeWidth));
+$switchHandleActivePosition: round(($size * $switchToBackgroundRatio) - ($size + ($switchHandleGap * 2 + $switchStrokeWidth)));
 
 $switchBackgroundOn: #57bd35;
 $switchBackgroundOff: #919191;
@@ -65,7 +65,7 @@ $installStripeColor2: #00c42e;
   }
 }
 
-@mixin stripes($color1, $color2) {
+@mixin stripes($color1, $color2, $stripeBackgroundColor) {
   animation: stripes 0.5s linear infinite;
   background-image:
     repeating-linear-gradient(
@@ -77,7 +77,7 @@ $installStripeColor2: #00c42e;
       $color1 50%
     );
   background-size: $size/2 $size/2;
-  background-color: $switchBackgroundOn;
+  background-color: $stripeBackgroundColor;
 }
 
 .switch {
@@ -93,7 +93,7 @@ $installStripeColor2: #00c42e;
     border: $switchStrokeWidth solid $switchStrokeOff;
     cursor: pointer;
     display: block;
-    height: $size + ($switchHandleGap * 2);
+    height: $size + ($switchHandleGap * 2) + ($switchStrokeWidth * 2);
     overflow: hidden;
     position: relative;
     width: round($size * $switchToBackgroundRatio);
@@ -143,7 +143,8 @@ $installStripeColor2: #00c42e;
     input + label::before {
       @include stripes(
         $uninstallStripeColor1,
-        $uninstallStripeColor2);
+        $uninstallStripeColor2,
+        $switchBackgroundOff);
       // Reverse the stripe direction without
       // impacting the animation speed.
       transform: scaleX(-1);
@@ -193,7 +194,8 @@ $installStripeColor2: #00c42e;
       &::before {
         @include stripes(
           $installStripeColor1,
-          $installStripeColor2);
+          $installStripeColor2,
+          $switchBackgroundOn);
       }
       &::after {
         transform: translateX($switchHandleActivePosition);
@@ -243,7 +245,7 @@ $installStripeColor2: #00c42e;
   &.enabled,
   &.installed {
     input + label::before {
-      background: $switchBackgroundOn url('tick.svg') no-repeat 35% 50%;
+      background: $switchBackgroundOn url('../img/tick.svg') no-repeat 35% 50%;
 
       [dir=rtl] & {
         background-position: 65% 50%;

--- a/data/recommendation/style.scss
+++ b/data/recommendation/style.scss
@@ -1,5 +1,9 @@
 @import "installButton";
 
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
 }
@@ -73,10 +77,12 @@ body {
 }
 
 #welcome {
-  height: 40px;
+  height: 65px;
   padding: 5px 10px 20px;
+  margin: 0;
   h3 {
     font-weight: normal;
+    margin: 0;
   }
 }
 

--- a/lib/Recommend.js
+++ b/lib/Recommend.js
@@ -11,8 +11,8 @@ const { Button } = require('lib/Button.js');
 const { TelemetryLog } = require('lib/TelemetryLog.js');
 
 const panelWidth = 402;
-const panelRecHeight = 101;
-const welcomeBoxHeight = 67;
+const panelRecHeight = 100;
+const welcomeBoxHeight = 65;
 const footerHeight = 42;
 
 class Recommender {


### PR DESCRIPTION
This is something that I should have done from the beginning. I thought that the effects of this rule were already in place by default, so I was confused several times when margins did not behave in a way that I expected. I didn't think that this was why though. 

Most notably, when I brought in `_installButton.scss` originally, the install button did not look as expected because the writers had assumed that border-box was applied somewhere else. I made some adjustments to it a while ago, not knowing that I should have used border box. I've now brought the original verison of _installButton from the disco page back in.

There were several css adjustments I had to make the switch to border-box. 

@mythmon r?
