### PR TITLE
Onboarding fix

### DIFF
--- a/data/recommendation/recWindow.html
+++ b/data/recommendation/recWindow.html
@@ -26,7 +26,7 @@
     <div id="welcome" hidden>
       <p>We'll show the green button above to recommend
       add-ons for the site you're visiting. Try out our
-      recommendation for Wikipedia!</p>
+      recommendation for Reddit!</p>
     </div>
     <div id="recs">
     </div>

--- a/lib/Recommend.js
+++ b/lib/Recommend.js
@@ -52,11 +52,8 @@ class Recommender {
   onboard() {
     this.panel.port.emit('onboard');
     tabs.open({
-      url: 'https://weather.com',
+      url: 'https://reddit.com',
       onReady: () => {
-        const win = tabs.activeTab.window;
-        const button = this.getButton(win);
-        this.showPanel(button);
         TelemetryLog.onboard();
         this.panel.on('hide', this.endOnboard);
       },
@@ -158,6 +155,9 @@ class Recommender {
         this.prepPanel(rec.data);
         TelemetryLog.showButton();
         button.show();
+        if (!simplePrefs.prefs.onboarded) {
+          this.showPanel(button);
+        }
         if (simplePrefs.prefs.autoOpenPanel && !rec.shown) {
           this.showPanel(button);
           rec.shown = true;


### PR DESCRIPTION
The onboarding event now uses RES as the default recommendation (for now, until Wikiwand is approved / denied). Onboarding event is also cleaned up to not force a panel open before it is ready. Now uses waitForWindow method that all other panel open events use. 

@gregglind r? 
