### PR TITLE
TelemetryLog use simpleData; no longer a singleton

### DIFF
--- a/lib/Recommend.js
+++ b/lib/Recommend.js
@@ -17,7 +17,7 @@ const onboardDomain = 'https://reddit.com';
 
 class Recommender {
   constructor() {
-    this.TelemetryLog = new TelemetryLog();
+    this.telemetryLog = new TelemetryLog();
     const methodsToBind = ['endOnboard', 'showPanel', 'waitForWindow',
                            'handlePanelHide', 'hidePanel'];
     for (let key of methodsToBind) { // eslint-disable-line prefer-const
@@ -52,7 +52,7 @@ class Recommender {
     tabs.open({
       url: onboardDomain,
       onReady: () => {
-        this.TelemetryLog.onboard(onboardDomain);
+        this.telemetryLog.onboard(onboardDomain);
         this.panel.on('hide', this.endOnboard);
       },
     });
@@ -61,7 +61,7 @@ class Recommender {
   endOnboard() {
     this.panel.removeListener('hide', this.endOnboard);
     this.panel.port.emit('endOnboard');
-    this.TelemetryLog.endOnboard();
+    this.telemetryLog.endOnboard();
     simplePrefs.prefs.onboarded = true;
     this.waitForWindow(); // reset the panel size
   }
@@ -77,7 +77,7 @@ class Recommender {
   }
 
   showPanel(button) {
-    this.TelemetryLog.showPanel(this.activeRecDomain);
+    this.telemetryLog.showPanel(this.activeRecDomain);
     button.handlePanelOpen();
     this.panel.show({
       position: button,
@@ -85,7 +85,7 @@ class Recommender {
   }
 
   handlePanelHide() {
-    this.TelemetryLog.hidePanel(this.activeRecDomain);
+    this.telemetryLog.hidePanel(this.activeRecDomain);
     const win = tabs.activeTab.window;
     const button = this.getButton(win);
     button.handlePanelHide();
@@ -152,7 +152,7 @@ class Recommender {
       if (tabs.activeTab.url.includes(rec.domain)) {
         this.activeRecDomain = rec.domain;
         this.prepPanel(rec.data);
-        this.TelemetryLog.showButton(this.activeRecDomain);
+        this.telemetryLog.showButton(this.activeRecDomain);
         button.show();
         if (!simplePrefs.prefs.onboarded) {
           this.showPanel(button);
@@ -201,7 +201,7 @@ class Recommender {
 
   createInstallListener() {
     this.panel.port.on('install', data => {
-      this.TelemetryLog.install(data);
+      this.telemetryLog.install(data);
       this.installAddon(data.packageURL);
     });
   }
@@ -221,7 +221,7 @@ class Recommender {
 
   createWhyListener() {
     this.panel.port.on('why', () => {
-      this.TelemetryLog.whyButtonClicked(this.activeRecDomain);
+      this.telemetryLog.whyButtonClicked(this.activeRecDomain);
     });
   }
 

--- a/lib/Recommend.js
+++ b/lib/Recommend.js
@@ -17,6 +17,7 @@ const onboardDomain = 'https://reddit.com';
 
 class Recommender {
   constructor() {
+    this.TelemetryLog = new TelemetryLog();
     const methodsToBind = ['endOnboard', 'showPanel', 'waitForWindow',
                            'handlePanelHide', 'hidePanel'];
     for (let key of methodsToBind) { // eslint-disable-line prefer-const
@@ -51,7 +52,7 @@ class Recommender {
     tabs.open({
       url: onboardDomain,
       onReady: () => {
-        TelemetryLog.onboard(onboardDomain);
+        this.TelemetryLog.onboard(onboardDomain);
         this.panel.on('hide', this.endOnboard);
       },
     });
@@ -60,7 +61,7 @@ class Recommender {
   endOnboard() {
     this.panel.removeListener('hide', this.endOnboard);
     this.panel.port.emit('endOnboard');
-    TelemetryLog.endOnboard();
+    this.TelemetryLog.endOnboard();
     simplePrefs.prefs.onboarded = true;
     this.waitForWindow(); // reset the panel size
   }
@@ -76,7 +77,7 @@ class Recommender {
   }
 
   showPanel(button) {
-    TelemetryLog.showPanel(this.activeRecDomain);
+    this.TelemetryLog.showPanel(this.activeRecDomain);
     button.handlePanelOpen();
     this.panel.show({
       position: button,
@@ -84,7 +85,7 @@ class Recommender {
   }
 
   handlePanelHide() {
-    TelemetryLog.hidePanel(this.activeRecDomain);
+    this.TelemetryLog.hidePanel(this.activeRecDomain);
     const win = tabs.activeTab.window;
     const button = this.getButton(win);
     button.handlePanelHide();
@@ -151,7 +152,7 @@ class Recommender {
       if (tabs.activeTab.url.includes(rec.domain)) {
         this.activeRecDomain = rec.domain;
         this.prepPanel(rec.data);
-        TelemetryLog.showButton(this.activeRecDomain);
+        this.TelemetryLog.showButton(this.activeRecDomain);
         button.show();
         if (!simplePrefs.prefs.onboarded) {
           this.showPanel(button);
@@ -200,7 +201,7 @@ class Recommender {
 
   createInstallListener() {
     this.panel.port.on('install', data => {
-      TelemetryLog.install(data);
+      this.TelemetryLog.install(data);
       this.installAddon(data.packageURL);
     });
   }
@@ -220,7 +221,7 @@ class Recommender {
 
   createWhyListener() {
     this.panel.port.on('why', () => {
-      TelemetryLog.whyButtonClicked(this.activeRecDomain);
+      this.TelemetryLog.whyButtonClicked(this.activeRecDomain);
     });
   }
 

--- a/lib/TelemetryLog.js
+++ b/lib/TelemetryLog.js
@@ -4,12 +4,13 @@ const xutils = require('shield-studies-addon-utils');
 class TelemetryLog {
   constructor() {
     if (!simpleStorage.storage.TelemetryLogData) {
-      simpleStorage.storage.TelemetryLogData = {};
-      simpleStorage.storage.TelemetryLogData.buttonShowCount = 0;
-      simpleStorage.storage.TelemetryLogData.panelShowCount = 0;
-      simpleStorage.storage.TelemetryLogData.installCount = 0;
-      simpleStorage.storage.TelemetryLogData.disableCount = 0;
-      simpleStorage.storage.TelemetryLogData.whyButtonCount = 0;
+      simpleStorage.storage.TelemetryLogData = {
+        buttonShowCount: 0,
+        panelShowCount: 0,
+        installCount: 0,
+        disableCount: 0,
+        whyButtonCount: 0,
+      };
     }
   }
 

--- a/lib/TelemetryLog.js
+++ b/lib/TelemetryLog.js
@@ -10,10 +10,6 @@ class TelemetryLog {
     simpleStorage.storage.telemetryLogData = newObject;
   }
 
-  increaseByOne(prop) {
-    simpleStorage.storage.telemetryLogData[prop] += 1;
-  }
-
   constructor() {
     if (!this.logData) {
       this.logData = {
@@ -46,7 +42,7 @@ class TelemetryLog {
     });
   }
   showPanel(domain) {
-    this.increaseByOne('panelShowCount');
+    this.logData.panelShowCount += 1;
     this.log({
       messageType: 'showPanel',
       domain,
@@ -65,7 +61,7 @@ class TelemetryLog {
   }
 
   showButton(domain) {
-    this.increaseByOne('buttonShowCount');
+    this.logData.buttonShowCount += 1;
     this.log({
       messageType: 'showButton',
       domain,
@@ -75,7 +71,7 @@ class TelemetryLog {
   }
 
   whyButtonClicked(domain) {
-    this.increaseByOne('whyButtonCount');
+    this.logData.whyButtonCount += 1;
     this.log({
       messageType: 'whyClick',
       domain,
@@ -85,7 +81,7 @@ class TelemetryLog {
   }
 
   install(addonData) {
-    this.increaseByOne('installCount');
+    this.logData.installCount += 1;
     this.log({
       messageType: 'install',
       addonData,
@@ -96,7 +92,7 @@ class TelemetryLog {
   }
 
   disableSite(domain) {
-    this.increaseByOne('disableCount');
+    this.logData.disableCount += 1;
     this.log({
       messageType: 'disableSite',
       domain,

--- a/lib/TelemetryLog.js
+++ b/lib/TelemetryLog.js
@@ -2,9 +2,21 @@ const simpleStorage = require('sdk/simple-storage');
 const xutils = require('shield-studies-addon-utils');
 
 class TelemetryLog {
+  get logData() {
+    return simpleStorage.storage.telemetryLogData;
+  }
+
+  set logData(newObject) {
+    simpleStorage.storage.telemetryLogData = newObject;
+  }
+
+  increaseByOne(prop) {
+    simpleStorage.storage.telemetryLogData[prop] += 1;
+  }
+
   constructor() {
-    if (!simpleStorage.storage.TelemetryLogData) {
-      simpleStorage.storage.TelemetryLogData = {
+    if (!this.logData) {
+      this.logData = {
         buttonShowCount: 0,
         panelShowCount: 0,
         installCount: 0,
@@ -34,12 +46,12 @@ class TelemetryLog {
     });
   }
   showPanel(domain) {
-    simpleStorage.storage.TelemetryLogData.panelShowCount += 1;
+    this.increaseByOne('panelShowCount');
     this.log({
       messageType: 'showPanel',
       domain,
       panelShowTime: Date.now(),
-      panelShowCount: simpleStorage.storage.TelemetryLogData.panelShowCount,
+      panelShowCount: this.logData.panelShowCount,
     });
   }
 
@@ -48,48 +60,48 @@ class TelemetryLog {
       messageType: 'hidePanel',
       domain,
       panelShowTime: Date.now(),
-      panelShowCount: simpleStorage.storage.TelemetryLogData.panelShowCount,
+      panelShowCount: this.logData.panelShowCount,
     });
   }
 
   showButton(domain) {
-    simpleStorage.storage.TelemetryLogData.buttonShowCount += 1;
+    this.increaseByOne('buttonShowCount');
     this.log({
       messageType: 'showButton',
       domain,
       buttonShowTime: Date.now(),
-      buttonShowCount: simpleStorage.storage.TelemetryLogData.buttonShowCount,
+      buttonShowCount: this.logData.buttonShowCount,
     });
   }
 
   whyButtonClicked(domain) {
-    this.whyButtonClicked += 1;
+    this.increaseByOne('whyButtonCount');
     this.log({
       messageType: 'whyClick',
       domain,
       whyClickTime: Date.now(),
-      whyClickCount: simpleStorage.storage.TelemetryLogData.whyButtonCount,
+      whyClickCount: this.logData.whyButtonCount,
     });
   }
 
   install(addonData) {
-    simpleStorage.storage.TelemetryLogData.installCount += 1;
+    this.increaseByOne('installCount');
     this.log({
       messageType: 'install',
       addonData,
       addonId: addonData.id,
       installRequestTime: Date.now(),
-      installCount: simpleStorage.storage.TelemetryLogData.installCount,
+      installCount: this.logData.installCount,
     });
   }
 
   disableSite(domain) {
-    simpleStorage.storage.TelemetryLogData.disableCount += 1;
+    this.increaseByOne('disableCount');
     this.log({
       messageType: 'disableSite',
       domain,
       installRequestTime: Date.now(),
-      disableCount: simpleStorage.storage.TelemetryLogData.disableCount,
+      disableCount: this.logData.disableCount,
     });
   }
 

--- a/lib/TelemetryLog.js
+++ b/lib/TelemetryLog.js
@@ -1,12 +1,16 @@
+const simpleStorage = require('sdk/simple-storage');
 const xutils = require('shield-studies-addon-utils');
 
 class TelemetryLog {
   constructor() {
-    this.buttonShowCount = 0;
-    this.panelShowCount = 0;
-    this.installCount = 0;
-    this.disableCount = 0;
-    this.whyButtonCount = 0;
+    if (!simpleStorage.storage.TelemetryLogData) {
+      simpleStorage.storage.TelemetryLogData = {};
+      simpleStorage.storage.TelemetryLogData.buttonShowCount = 0;
+      simpleStorage.storage.TelemetryLogData.panelShowCount = 0;
+      simpleStorage.storage.TelemetryLogData.installCount = 0;
+      simpleStorage.storage.TelemetryLogData.disableCount = 0;
+      simpleStorage.storage.TelemetryLogData.whyButtonCount = 0;
+    }
   }
 
   log(data) {
@@ -29,12 +33,12 @@ class TelemetryLog {
     });
   }
   showPanel(domain) {
-    this.panelShowCount += 1;
+    simpleStorage.storage.TelemetryLogData.panelShowCount += 1;
     this.log({
       messageType: 'showPanel',
       domain,
       panelShowTime: Date.now(),
-      panelShowCount: this.panelShowCount,
+      panelShowCount: simpleStorage.storage.TelemetryLogData.panelShowCount,
     });
   }
 
@@ -43,17 +47,17 @@ class TelemetryLog {
       messageType: 'hidePanel',
       domain,
       panelShowTime: Date.now(),
-      panelShowCount: this.panelShowCount,
+      panelShowCount: simpleStorage.storage.TelemetryLogData.panelShowCount,
     });
   }
 
   showButton(domain) {
-    this.buttonShowCount += 1;
+    simpleStorage.storage.TelemetryLogData.buttonShowCount += 1;
     this.log({
       messageType: 'showButton',
       domain,
       buttonShowTime: Date.now(),
-      buttonShowCount: this.buttonShowCount,
+      buttonShowCount: simpleStorage.storage.TelemetryLogData.buttonShowCount,
     });
   }
 
@@ -63,28 +67,28 @@ class TelemetryLog {
       messageType: 'whyClick',
       domain,
       whyClickTime: Date.now(),
-      whyClickCount: this.whyButtonCount,
+      whyClickCount: simpleStorage.storage.TelemetryLogData.whyButtonCount,
     });
   }
 
   install(addonData) {
-    this.installCount += 1;
+    simpleStorage.storage.TelemetryLogData.installCount += 1;
     this.log({
       messageType: 'install',
       addonData,
       addonId: addonData.id,
       installRequestTime: Date.now(),
-      installCount: this.installCount,
+      installCount: simpleStorage.storage.TelemetryLogData.installCount,
     });
   }
 
   disableSite(domain) {
-    this.disableCount += 1;
+    simpleStorage.storage.TelemetryLogData.disableCount += 1;
     this.log({
       messageType: 'disableSite',
       domain,
       installRequestTime: Date.now(),
-      disableCount: this.disableCount,
+      disableCount: simpleStorage.storage.TelemetryLogData.disableCount,
     });
   }
 
@@ -97,4 +101,4 @@ class TelemetryLog {
   }
 }
 
-exports.TelemetryLog = new TelemetryLog();
+exports.TelemetryLog = TelemetryLog;


### PR DESCRIPTION
TelemetryLog counts of events are now stored persistently in simpleStorage. Class is now exported to be instatiated by Recommender class. Closes #58

@Osmose r?
