### PR TITLE
User feedback indicates that wikipedia tab is opened on every startup

### DIFF
--- a/lib/Recommend.js
+++ b/lib/Recommend.js
@@ -2,7 +2,7 @@ const { AddonManager } = require('resource://gre/modules/AddonManager.jsm');
 const { Panel: panel } = require('sdk/panel');
 const self = require('sdk/self');
 const sdkUrl = require('sdk/url');
-const simplePrefs = require('sdk/simple-prefs');
+const prefSvc = require('sdk/preferences/service');
 const simpleStorage = require('sdk/simple-storage');
 const tabs = require('sdk/tabs');
 const { viewFor } = require('sdk/view/core');
@@ -15,6 +15,8 @@ const panelRecHeight = 100;
 const welcomeBoxHeight = 70;
 const footerHeight = 42;
 const onboardDomain = 'https://wikipedia.org';
+
+const AUTOOPENPREF = `extensions.${self.preferencesBranch}.autoOpenPanel`;
 
 class Recommender {
   constructor() {
@@ -29,15 +31,16 @@ class Recommender {
     this.panel = this.createPanel();
     this.createRequestListeners();
     this.createWindowListeners();
+    this.onboarding = false;
   }
 
-  start() {
+  start(reason) {
     this.populateInstallSet();
     if (!simpleStorage.storage.recData) {
       simpleStorage.storage.recData = this.loadLocalRecs();
     }
     this.activeRecDomain = '';
-    if (!simplePrefs.prefs.onboarded) {
+    if (reason === 'install') {
       this.onboard();
     }
   }
@@ -50,6 +53,8 @@ class Recommender {
 
   onboard() {
     this.panel.port.emit('onboard');
+    this.onboarding = true;
+
     tabs.open({
       url: onboardDomain,
       onReady: () => {
@@ -63,7 +68,7 @@ class Recommender {
     this.panel.removeListener('hide', this.endOnboard);
     this.panel.port.emit('endOnboard');
     this.telemetryLog.endOnboard();
-    simplePrefs.prefs.onboarded = true;
+    this.onboarding = false;
     this.waitForWindow(); // reset the panel size
   }
 
@@ -100,7 +105,7 @@ class Recommender {
   prepPanel(recs) {
     const markedRecs = this.checkForInstalled(recs);
     this.panel.height = recs.length * panelRecHeight + footerHeight;
-    if (!simplePrefs.prefs.onboarded) {
+    if (this.onboarding) {
       this.panel.height += welcomeBoxHeight;
     }
     this.panel.port.emit('data', markedRecs);
@@ -157,11 +162,12 @@ class Recommender {
   offerRecommendation(button, rec) {
     this.telemetryLog.showButton(this.activeRecDomain);
     button.show();
-    if (!simplePrefs.prefs.onboarded) {
+    if (this.isOnboarding) {
       this.showPanel(button);
-    }
-    if (simplePrefs.prefs.autoOpenPanel && !rec.shown) {
-      this.showPanel(button);
+    } else {
+      if (prefSvc.get(AUTOOPENPREF) && !rec.shown) {
+        this.showPanel(button);
+      }
     }
   }
 
@@ -174,7 +180,7 @@ class Recommender {
       if (tabHostname === rec.domain) {
         this.activeRecDomain = rec.domain;
         const markedRecs = this.prepPanel(rec.data);
-        if (!this.allInstalledAlready(markedRecs) || !simplePrefs.prefs.onboarded) {
+        if (!this.allInstalledAlready(markedRecs) || this.isOnboarding) {
           this.offerRecommendation(button, rec);
           rec.shown = true;
         }

--- a/lib/variations.js
+++ b/lib/variations.js
@@ -1,17 +1,18 @@
 const { Recommender } = require('./Recommend.js');
 const simplePrefs = require('sdk/simple-prefs');
+const self = require("sdk/self");
 
 let Rec = null;
 
 const variations = {
   'passive-panel'() {
     Rec = new Recommender();
-    Rec.start();
+    Rec.start(self.loadReason);
   },
   'auto-open-panel'() {
     simplePrefs.prefs.autoOpenPanel = true;
     Rec = new Recommender();
-    Rec.start();
+    Rec.start(self.loadReason);
   },
   'observe-only'() {},
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Site Enhance Shield Study",
   "name": "site-enhance-shield-study",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Shield Study add-on for recommending add-ons based on domain",
   "main": "index.js",
   "author": "Mozilla Foundation",
@@ -16,16 +16,17 @@
   "scripts": {
     "styles": "node_modules/.bin/node-sass data/recommendation --output data/recommendation --sourcemap=none",
     "build": "npm run styles && jpm xpi",
-    "lint": "eslint lib data"
+    "lint": "eslint lib data",
+    "test": "jpm test"
   },
   "devDependencies": {
-    "jpm": "1.0.7",
     "eslint": "2.13.1",
     "eslint-config-airbnb": "9.0.1",
     "eslint-plugin-import": "1.10.2",
     "eslint-plugin-jsx-a11y": "1.5.5",
     "eslint-plugin-mozilla": "0.0.3",
     "eslint-plugin-react": "5.2.2",
+    "jpm": "1.1.4",
     "node-sass": "3.8.0",
     "woodchipper": "0.9.1"
   },

--- a/test/test-recommend.js
+++ b/test/test-recommend.js
@@ -1,0 +1,47 @@
+const { Recommender } = require("../lib/Recommend");
+
+const tabs = require("sdk/tabs");
+function only1Tab () {
+  let first = true;
+  for (let tab of tabs) {
+    if (first) {
+      first = false;
+      continue;
+    }
+    tab.close();
+  }
+}
+
+
+exports['test only onboard while installing'] = function (assert) {
+  assert.pass();
+};
+
+
+
+exports['test onboarding' ] = function (assert) {
+  let R;
+
+  console.log(Object.keys(assert));
+
+  // install
+  R = new Recommender();
+  console.log(R.onboarding);
+  assert.ok(!R.onboarding, "R should NOT be onboarding yet.");
+  R.start('install');
+  assert.ok(R.onboarding, "R should onboarding yet.");
+  R.destroy()
+
+  // startup
+  R = new Recommender();
+  assert.ok(!R.onboarding, "R should NOT be onboarding.");
+  R.start('startup');
+  assert.ok(!R.onboarding, "R should STILL NOT be onboarding.");
+  R.destroy();
+
+
+  only1Tab();
+}
+
+
+require("sdk/test").run(exports);


### PR DESCRIPTION
This bug is likely in the onboarding event. In this event, a new tab of wikipedia is opened, and users are shown how to use addon recommendation. The feedback suggests that this event is happening on every startup when it should only happen when the addon is installed. 
