### PR TITLE
Resolve onboarding bug where wikipedia is opened on every startup

### DIFF
--- a/lib/Recommend.js
+++ b/lib/Recommend.js
@@ -49,6 +49,7 @@ class Recommender {
   }
 
   onboard() {
+    simplePrefs.prefs.onboarded = true;
     this.panel.port.emit('onboard');
     tabs.open({
       url: onboardDomain,
@@ -63,7 +64,6 @@ class Recommender {
     this.panel.removeListener('hide', this.endOnboard);
     this.panel.port.emit('endOnboard');
     this.telemetryLog.endOnboard();
-    simplePrefs.prefs.onboarded = true;
     this.waitForWindow(); // reset the panel size
   }
 


### PR DESCRIPTION
This is a clean solution to the issue in #89.

@mythmon r?
