### PR TITLE
Refactoring of onboarding code (better fix for #91)

### DIFF
--- a/lib/Recommend.js
+++ b/lib/Recommend.js
@@ -49,11 +49,10 @@ class Recommender {
   }
 
   onboard() {
-    simplePrefs.prefs.onboarded = true;
     this.panel.port.emit('onboard');
     tabs.open({
       url: onboardDomain,
-      onReady: () => {
+      onOpen: () => {
         this.telemetryLog.onboard(onboardDomain);
         this.panel.on('hide', this.endOnboard);
       },
@@ -61,6 +60,7 @@ class Recommender {
   }
 
   endOnboard() {
+    simplePrefs.prefs.onboarded = true;
     this.panel.removeListener('hide', this.endOnboard);
     this.panel.port.emit('endOnboard');
     this.telemetryLog.endOnboard();


### PR DESCRIPTION
There are several methods that rely on the simple pref that marks the onboarding as complete. #91 alters the way the simple pref is used, which causes several issues. This commit fixes the issue that #91 fixes, but in a way which does not break the methods that depend specific usage of the onboarding pref.

The key change is that the tabs event listener that calls the endOnboard method is now the onOpen listener, rather than the onReady. onOpen fires immediately when the tab opens, while onReady fires once the page is completely loaded. Use of onReady contributed to the repeated onboarding events some users expirienced, as closing the tab before it loads completely would mean the onboarding complete pref was never set to true.

Testing using the same procedures as #91, namely simulating a 100% loss network on my computer and installing the addon on a fresh firefox build (to test closing the onboarding tab before it fully loads), showed that this commit fixes the issue of repeated onboarding events. Additionally, the methods that rely on the onboarding pref are not broken in this commit, as the usage of the pref is returned to the way it was previously.

@mythmon r?
