### PR TITLE
Delete simple-storage on cleanup

### DIFF
--- a/lib/Recommend.js
+++ b/lib/Recommend.js
@@ -1,5 +1,6 @@
 const { AddonManager } = require('resource://gre/modules/AddonManager.jsm');
 const { Panel: panel } = require('sdk/panel');
+const preferenceService = require('sdk/preferences/service');
 const self = require('sdk/self');
 const sdkUrl = require('sdk/url');
 const simplePrefs = require('sdk/simple-prefs');
@@ -46,7 +47,8 @@ class Recommender {
     this.panel.destroy();
     this.removeWindowListener();
     this.deleteButtons();
-    delete simpleStorage.storage;
+    preferenceService.reset('extensions.@site-enhance-shield-study.onboarded');
+    preferenceService.reset('extensions.@site-enhance-shield-study.autoOpenPanel');
   }
 
   onboard() {

--- a/lib/Recommend.js
+++ b/lib/Recommend.js
@@ -46,6 +46,7 @@ class Recommender {
     this.panel.destroy();
     this.removeWindowListener();
     this.deleteButtons();
+    delete simpleStorage.storage;
   }
 
   onboard() {


### PR DESCRIPTION
I'm able to remove simple storage data, as requested in #90.

However, I haven't been able to find a way to delete addon preferences. The [simple-prefs docs](https://developer.mozilla.org/en-US/Add-ons/SDK/High-Level_APIs/simple-prefs) doesn't mention any way to do this. @mythmon @gregglind do you know of a way to delete preferences? 

@mythmon r?
